### PR TITLE
Grammar nit: its -> it's, and add missing "is"

### DIFF
--- a/jekyll/_posts/2018-06-03-why-doesnt-go-have-variance-in.markdown
+++ b/jekyll/_posts/2018-06-03-why-doesnt-go-have-variance-in.markdown
@@ -21,8 +21,8 @@ that a value of type A can always be used, where a value of type B is required.
 Go doesn't have explicit subtype relationships - the closest it has is
 [assignability](https://golang.org/ref/spec#Assignability) which mostly
 determines whether types can be used interchangeably. Probably the most
-important case of this is given by interfaces: If a type T (whether its a
-concrete type, or itself an interface) implements an interface I, then T can be
+important case of this is given by interfaces: If a type T (whether it's a
+concrete type, or is itself an interface) implements an interface I, then T can be
 viewed as a subtype of I. In that sense,
 [`*bytes.Buffer`](https://godoc.org/bytes#Buffer) is a subtype of
 [io.ReadWriter](https://godoc.org/io#ReadWriter), which is a subtype of


### PR DESCRIPTION
Was reading your article about Go variance and noticed two tiny nits in this parenthesis: 1) "its" is short for "it is" here so should be "it's", and 2) "or itself an interface" doesn't parse very well; adding "is".